### PR TITLE
Google検索の最新・リアルタイム検索への対応

### DIFF
--- a/chrome/content/browser/30-SearchEmbedder.js
+++ b/chrome/content/browser/30-SearchEmbedder.js
@@ -113,7 +113,7 @@ extend(SearchEmbedder.prototype, {
         let head = this.doc.getElementsByTagName("head")[0];
         if (!head) return;
         let style = this.doc.createElement("style");
-        style.textContent = SearchEmbedder.STYLE + (this.site.data.style || "");
+        style.textContent = SearchEmbedder.STYLE + (this.site.query("style", this.doc) || "");
         head.appendChild(style);
     },
 
@@ -122,7 +122,7 @@ extend(SearchEmbedder.prototype, {
         let annotation = this.site.query("annotation", this.doc);
         if (!annotation) return null;
         let range = this.doc.createRange();
-        switch (this.site.data.annotationPosition || "last") {
+        switch (this.site.query("annotationPosition", this.doc) || "last") {
         case "before":
             range.selectNode(annotation);
             range.collapse(true);

--- a/resources/modules/30-SiteInfoSet-Search.jsm
+++ b/resources/modules/30-SiteInfoSet-Search.jsm
@@ -31,33 +31,62 @@ let builtInSearchSiteInfo = [
                 table.tBodies[0].appendChild(tr);
                 return td;
             }
+            if(doc.URL.match(/tbs=(rltm|mbl)/)){
+                let block = doc.getElementById("rhs_block");
+                if(block){
+                    return block;
+                }
+            }
             return doc.getElementById("res");
         },
-        annotationPosition: 'first',
-        style: <![CDATA[
-            td > #hBookmark-search {
-                margin: 1em 0 0 0;
-                width: auto;
-                float: none;
-                white-space: normal;
+        annotationPosition: function (doc) {
+            if(doc.URL.match(/tbs=(rltm|mbl)/)){
+                return 'last';
+            }else{
+                return 'first';
             }
-            div > #hBookmark-search {
-                font-size: 0.8em;
-                margin-right: -32%;
+        },
+        style: function (doc) {
+            let style = <![CDATA[
+                td > #hBookmark-search {
+                    margin: 1em 0 0 0;
+                    width: auto;
+                    float: none;
+                    white-space: normal;
+                }
+                div > #hBookmark-search {
+                    font-size: 0.8em;
+                    margin-right: -32%;
+                }
+            ]]>.toString();
+            if(doc.URL.match(/tbs=(rltm|mbl)/)){
+                style += <![CDATA[
+                    div > #hBookmark-search {
+                        margin-right: auto;
+                        padding-left: 15px;
+                        float: none;
+                        width: auto;
+                    }
+                ]]>.toString();
             }
-        ]]>.toString(),
+            return style;
+        },
     },
     { // Yahoo Web Search
         url:        /^http:\/\/search\.yahoo(?:\.\w+){1,2}\/search\?/,
         baseDomain: /^yahoo\./,
         query:      /[?&;]p=([^?&;#]+)/,
         encoding:   /[?&;]ei=([\w-]+)/,
-        annotation: 'id("sIn")',
-        style: <![CDATA[
-            #hBookmark-search {
-                width: auto;
-            }
-        ]]>.toString(),
+        annotation: function (doc) {
+            return doc.getElementById("sIn");
+        },
+        style: function (doc) {
+            return <![CDATA[
+                #hBookmark-search {
+                    width: auto;
+                }
+            ]]>.toString();
+        },
     },
 ];
 


### PR DESCRIPTION
｢検索サイトにマイブックマーク全文検索結果を表示する｣を有効にしてGoogleで検索したとき右カラムに地図やハッシュタグの情報を表示されると，はてブの検索結果とかぶってしまう
http://i.hatena.ne.jp/idea/29312
への対応です。

googleのクエリ
「期間指定最新」
http://www.google.co.jp/search?q=JR&num=100&hl=ja&newwindow=1&safe=off&client=firefox-a&rls=org.mozilla:ja:official&prmdo=1&prmd=ivnsum&source=lnt&tbs=rltm:1&sa=X&ei=MWV_TZjgFomIuAPOlKXoBw&ved=0CAsQpwUoAQ

「リアルタイム」
http://www.google.co.jp/search?num=100&hl=ja&lr=lang_ja&newwindow=1&safe=off&client=firefox-a&rls=org.mozilla%3Aja%3Aofficial&tbs=mbl%3A1%2Clr%3Alang_1ja&q=JR&aq=f&aqi=g2g-z1g6g-r1&aql=&oq=

に対応しました。クエリ文字列の

tbs=rltm　（最新）
tbs=mbl　（リアルタイム）

が目印になるのですが、resource/modules/30-SiteInfoSet-Search.jsmのurlで対応するのはどうかと思ったので、styleとannotationPositionを関数化しました。

もし、問題ないようであればマージしていただければと思います。
