### PR TITLE
VimperatorプラグインでLivedoor Readerでコメント読めるようにしました

### DIFF
--- a/chrome/content/vimperator/plugin/hatenabookmark.js
+++ b/chrome/content/vimperator/plugin/hatenabookmark.js
@@ -297,6 +297,12 @@ liberator.plugins.hBookmark = (function() {
     plugin.command.options.completer = plugin.command.createCompleter(['URL','Comment']);
 
     plugin.toggleComment = function(url) {
+        if (!url && content.location.href.indexOf('reader.livedoor.com/reader') >= 0) {
+              let item = content.window.wrappedJSObject.get_active_item(true);
+              if (item) {
+                  url = item.link;
+              }
+        }
         HatenaBookmark.CommentViewer.toggle(url);
     }
 


### PR DESCRIPTION
機能追加しました．

Vimperatorプラグインで，Livedoor Readerを見ているとき，ブックマークに追加しようとすると，Livedoor Readerではなく，今見ているエントリをブックマークに追加するようになっていますが，それと同様に，ブックマークコメントを見るときも，今見ているエントリのブックマークコメントを見られるようにしました．

よろしくお願いします．
