### PR TITLE
Fix to load over 30 bookmarks

### DIFF
--- a/chrome/content/browser/15-CommentViewer.js
+++ b/chrome/content/browser/15-CommentViewer.js
@@ -386,7 +386,7 @@ var CommentViewer = {
     lazyTimerHandler: function(ev) {
         let bs = CommentViewer.lazyWriterBookmarks;
         if (bs && bs.length) {
-            let fragment = CommentViewer.renderComment(bs, 50, fragment);
+            let fragment = CommentViewer.renderComment(bs, 50);
             list.appendChild(fragment);
             CommentViewer.renderPendingStars();
         }


### PR DESCRIPTION
"lazy loading" feature is broken by referencing uninitialized object.