### PR TITLE
Fix ReferenceError: CompletionContext is not defined

### DIFF
--- a/chrome/content/vimperator/plugin/hatenabookmark.js
+++ b/chrome/content/vimperator/plugin/hatenabookmark.js
@@ -302,7 +302,7 @@ liberator.plugins.hBookmark = (function() {
                 context.incomplete = true;
                 context.filters = [];
                 context.anchored = true;
-                context.compare = CompletionContext.Sort.unsorted;
+                context.compare = null;
                 context.regenerate = true;
                 context.generate = function () plugin.command._search(context, searchMethod);
             }


### PR DESCRIPTION
Firefox44からのconstの仕様変更によりエラーが出ていました。
CompletionContext.Sort.unsortedはnull
https://github.com/vimperator/vimperator-labs/blob/ee51e9964df7c1ae3697ff585dfdd4ed79c17714/common/content/completion.js#L627
なので、代わりにnullを使用するように変更しました。