### PR TITLE
サイドバーでタグをクリックしてもブックーマーク一覧が更新されない件を修正

### DIFF
--- a/chrome/content/sidebar/10-BookmarkTreeView.js
+++ b/chrome/content/sidebar/10-BookmarkTreeView.js
@@ -49,7 +49,22 @@ extend(BookmarkTreeView.prototype, {
 
     showByTags: function (tags) {
         this._update = function BTV_doUpdateByTags(callback) {
-            let bookmarks = Bookmark.findByTags(tags);
+            var bids;
+            for (var i = 0; i < tags.length; i++) {
+                var cond = { where: "name = :name", name: tags[i] };
+                if (bids) {
+                    cond.where +=
+                    " AND bookmark_id IN (" + bids.join(",") + ")";
+                }
+                bids = Model.Tag.find(cond).map(function (tag) tag.bookmark_id);
+                if (!bids.length)
+                	return;
+            }
+            let query = {
+                where: 'id IN (' + bids.join(',') + ')',
+                order: 'date asc'
+            };
+            let bookmarks = Model.Bookmark.find(query);
             if (this.isAscending) bookmarks.reverse();
             this.setBookmarksAsync(bookmarks, callback);
         };


### PR DESCRIPTION
こんにちは。

タイトルの修正を試みました。
findByTagsを呼び出すのではなく、showByTag内に処理を記述しています。
findByTags以降はそのままとし変更していません。（調べた範囲では他では使用されていない模様）

pull requestは始めてなので、無作法になっているかもしれません。
その場合はご容赦ください。
