### PR TITLE
Fx46 対応: 配列内包表記を使用しないよう変更

### DIFF
--- a/chrome/content/browser/05-Migration.js
+++ b/chrome/content/browser/05-Migration.js
@@ -31,43 +31,43 @@ Migration.Migrations = [
     function M_1_toolbarMenuInstall() {
         // やっぱり標準ではインストールしない
         return;
-        var toolbar = document.getElementById('nav-bar');
-        try {
-            // Fx 3.0 unified-back-forward-button,reload-button,stop-button,home-button,
-            // hBookmark-toolbar-home,quickrestart-button,urlbar-container,search-container
-            let bars = toolbar.currentSet.split(',');
-            bars = bars.filter(function(n) n.indexOf('hBookmark-toolbar-' == -1));
+        // var toolbar = document.getElementById('nav-bar');
+        // try {
+        //     // Fx 3.0 unified-back-forward-button,reload-button,stop-button,home-button,
+        //     // hBookmark-toolbar-home,quickrestart-button,urlbar-container,search-container
+        //     let bars = toolbar.currentSet.split(',');
+        //     bars = bars.filter(function(n) n.indexOf('hBookmark-toolbar-' == -1));
 
-            let lastButton = null;
-            let flag = false;
-            let newSet = [];
+        //     let lastButton = null;
+        //     let flag = false;
+        //     let newSet = [];
 
-            for (let i = 0;  i < bars.length; i++) {
-                let name = bars[i];
-                let el = document.getElementById(name);
-                if (flag) {
-                    //
-                } else if (el && name.indexOf('-button') >= 0 ) {
-                    lastButton = el;
-                } else if (lastButton) {
-                    // -button という ID が無くなった直後に追加
-                    newSet.push('hBookmark-toolbar-add-button');
-                    newSet.push('hBookmark-toolbar-home-button');
-                    // newSet.push('hBookmark-toolbar-dropdown');
-                    flag = true;
-                }
-                newSet.push(name);
-            }
-            if (flag) {
-                newSet = newSet.join(',');
-                toolbar.currentSet = newSet;
-                toolbar.setAttribute('currentset', newSet);
-                document.getElementById('navigator-toolbox').ownerDocument.persist(toolbar.id, 'currentset');
-                BrowserToolboxCustomizeDone(true);
-            }
-        } catch(e) {
-            p('install fail!: ' + e.toString());
-        }
+        //     for (let i = 0;  i < bars.length; i++) {
+        //         let name = bars[i];
+        //         let el = document.getElementById(name);
+        //         if (flag) {
+        //             //
+        //         } else if (el && name.indexOf('-button') >= 0 ) {
+        //             lastButton = el;
+        //         } else if (lastButton) {
+        //             // -button という ID が無くなった直後に追加
+        //             newSet.push('hBookmark-toolbar-add-button');
+        //             newSet.push('hBookmark-toolbar-home-button');
+        //             // newSet.push('hBookmark-toolbar-dropdown');
+        //             flag = true;
+        //         }
+        //         newSet.push(name);
+        //     }
+        //     if (flag) {
+        //         newSet = newSet.join(',');
+        //         toolbar.currentSet = newSet;
+        //         toolbar.setAttribute('currentset', newSet);
+        //         document.getElementById('navigator-toolbox').ownerDocument.persist(toolbar.id, 'currentset');
+        //         BrowserToolboxCustomizeDone(true);
+        //     }
+        // } catch(e) {
+        //     p('install fail!: ' + e.toString());
+        // }
     },
     function M_2_openStartPage() {
         // // 初回インストール時に、start ページを表示する

--- a/chrome/content/common/02-utils.js
+++ b/chrome/content/common/02-utils.js
@@ -58,7 +58,6 @@ Timer.prototype = {
 }
 
 
-var EXPORT = [m for (m in new Iterator(this, true))
-                          if (m[0] !== "_" && m !== "EXPORT")];
+var EXPORT = Object.keys(this).filter(name => name[0] !== "_" && name !== "EXPORT");
 
 

--- a/chrome/content/common/40-UIUtils.js
+++ b/chrome/content/common/40-UIUtils.js
@@ -217,7 +217,7 @@ var UIUtils = {
         let get = PluralForm.makeGetter(ruleNum)[0];
         let text = get(count, this.addPanelStrings.get("usersLabel"));
         return text.replace(/#1/g, count);
-        return count + " users";
+        // return count + " users";
     },
 
     deleteContents: function UIU_deleteContents(element) {

--- a/resources/modules/00-utils.jsm
+++ b/resources/modules/00-utils.jsm
@@ -494,11 +494,9 @@ var update = function (self, obj/*, ... */) {
     }
     return self;
 };
-var EXPORTED_SYMBOLS = [m for (m in new Iterator(this, true))
-                          if (m[0] !== "_" && m !== "EXPORTED_SYMBOLS")];
+var EXPORTED_SYMBOLS = Object.keys(this).filter(name => name[0] !== "_" && name !== "EXPORTED_SYMBOLS");
 
 /* Debug
 EXPORTED_SYMBOLS.push.apply(EXPORTED_SYMBOLS,
-                            [m for (m in new Iterator(this, true))
-                               if (m[0] === "_")]);
+                            Object.keys(this).filter(name => name[0] === "_"));
 //*/

--- a/resources/modules/52-utils.js
+++ b/resources/modules/52-utils.js
@@ -29,8 +29,8 @@ var sprintf = function (str) {
 /*
  * グローバル関数としてエクスポートはしないけど、あったら便利な関数など
  */
-var keys = function(obj) [key for (key in obj)];
-var values = function(obj) [key for each (key in obj)];
+var keys = (obj => Object.keys(obj));
+var values = (obj => Object.keys(obj).map(key => obj[key]));
 
 var getHistoryNodeByURL = function getHistoryNodeByURL(url) {
     let query = HistoryService.getNewQuery();
@@ -210,5 +210,4 @@ var parseShortcut = function parseShortcut(aShortcut) {
 }
 
 
-var EXPORTED_SYMBOLS = [m for (m in new Iterator(this, true))
-                          if (m[0] !== "_" && m !== "EXPORTED_SYMBOLS")];
+var EXPORTED_SYMBOLS = Object.keys(this).filter(name => name[0] !== "_" && name !== "EXPORTED_SYMBOLS");

--- a/resources/modules/60-Database.js
+++ b/resources/modules/60-Database.js
@@ -602,7 +602,7 @@ extend(Entity, {
     },
     
     createInsertSQL : function(def){
-        var fields =  [key for (key in def.fields)]
+        var fields = Object.keys(def.fields);
         var params = fields.map(function(p){
             return ':' + p
         });
@@ -614,7 +614,7 @@ extend(Entity, {
     },
     
     createUpdateSQL : function(def){
-        var fieldsStr = [key for (key in def.fields)].
+        var fieldsStr = Object.keys(def.fields).
             filter(function(p){return p!='id'}).
             map(function(p){
                 return p + '=:' + p;

--- a/resources/modules/82-RemoteCommand.js
+++ b/resources/modules/82-RemoteCommand.js
@@ -103,7 +103,7 @@ extend(RemoteCommand.prototype, {
 
     // nsIDOMEventListener (for nsIXMLHttpRequest)
     handleEvent: function RC_handleEvent(event) {
-        p([key + ': ' + value for ([key, value] in Iterator(event))].join("\n"));
+        p(Object.keys(event).map(key => key + ': ' + event[key]).join("\n"));
         p(this._request.status + "\n" + this._request.responseText);
         let status = (event.type === "load") ? this._request.status : 0;
         // HTTP ステータスコードが 200 なら成功として終了、

--- a/tests/javascripts/suffixarray.test.js
+++ b/tests/javascripts/suffixarray.test.js
@@ -51,7 +51,7 @@ function testNagayama() {
     return;
     var word = 'ブックマーク';
     //p.b(function() {
-        // indexes = [i for (i in finder)];
+        // indexes = Object.keys(finder);
         indexes = sary.search(word);
     //}, 'search');
 
@@ -89,6 +89,6 @@ function testSuffixArray()
     assert.equals(index, sary.length - 1);
 
     finder = sary.finder('ba');
-    let indexes = [i for (i in finder)];
+    let indexes = Object.keys(finder);
     assert.equals([3,6,13], indexes);
 }


### PR DESCRIPTION
Firefox 46 にて、JavaScript 1.7 で導入された配列内包表記のサポートが打ち切られた。
また、ECMAScript でも配列内包表記がサポートされるか否か不透明であったため、
配列内包表記を利用しないことにした。